### PR TITLE
Duas opções REDIS_HOST no README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ LISA_URL=<lisa_url>
 BACKEND_URL=None
 SETTINGS_MODULE=development
 REDIS_HOST=<redis_server_host>
-REDIS_HOST=<redis_server_port>
+REDIS_PORT=<redis_server_port>
 ```
 
 You should configure your own environment cloning both lisa and bot api:


### PR DESCRIPTION
Duas opções REDIS_HOST na instrução do README.md onde deveria ser REDIS_PORT